### PR TITLE
Add `ranks_per_bundle` parameter to extract_frame

### DIFF
--- a/bin/desi_benchmark_extract
+++ b/bin/desi_benchmark_extract
@@ -73,6 +73,8 @@ parser.add_argument("--pixpad-frac", type=float, default=0,
     help="fraction of a PSF spotsize to pad in pixels when extracting")
 parser.add_argument("--wavepad-frac", type=float, default=0, 
     help="fraction of a PSF spotsize to pad in wavelengths when extracting")
+parser.add_argument("--ranks-per-bundle", type=int, default=None, 
+    help="number of ranks per bundle")
 args = parser.parse_args()
 
 start_time = args.start_time
@@ -252,6 +254,9 @@ for camera in group_cameras:
 
     if args.gpu:
         cmd = cmd + " --gpu"
+
+    if args.ranks_per_bundle:
+        cmd = cmd + f" --ranks-per-bundle {args.ranks_per_bundle}"
 
     if group_rank == 0:
         print(rank, cmd)

--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -474,16 +474,16 @@ def extract_frame(img, psf, bundlesize, specmin, nspec, wavelength=None, nwavest
     bundle_comm, frame_comm, frame_rank, frame_size = decompose_comm(comm, gpu, ranks_per_bundle)
 
     if bundle_comm is None:
-        bundle_rank = 1
+        my_bundle_rank = 0
     else:
-        bundle_rank = bundle_comm.rank
+        my_bundle_rank = bundle_comm.rank
 
     if frame_comm is None:
-        frame_rank = 1
+        my_frame_rank = 0
     else:
-        frame_rank = frame_comm.rank
+        my_frame_rank = frame_comm.rank
 
-    log.info(f"{rank=} {frame_rank=} {bundle_rank=}")
+    log.info(f"{rank=} {my_frame_rank=} {my_bundle_rank=}")
 
     timer.split('init-mpi-comm')
     time_init_mpi_comm = time.time()

--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -444,6 +444,7 @@ def extract_frame(img, psf, bundlesize, specmin, nspec, wavelength=None, nwavest
         pixpad_frac: fraction of a PSF spotsize to pad in pixels when extracting
         wavepad_frac: fraction of a PSF spotsize to pad in wavelengths when extracting
         batch_subbundle: perform extraction in subbundle batch of patches (GPU-only)
+        ranks_per_bundle: number of mpi ranks per bundle comm
 
     Returns:
         frame: dictionary frame object (see gpu_specter.io.write_frame)

--- a/py/gpu_specter/spex.py
+++ b/py/gpu_specter/spex.py
@@ -51,11 +51,11 @@ def parse(options=None):
                         help="use asynchronous read/write mpi comm")
     parser.add_argument("--pixpad-frac", type=float, required=False, default=0.8,
                         help="fraction of a PSF spotsize to pad in pixels when extracting")
-    parser.add_argument("--wavepad-frac", type=float, default=0.2, 
+    parser.add_argument("--wavepad-frac", type=float, default=0.2,
                         help="fraction of a PSF spotsize to pad in wavelengths when extracting")
-    parser.add_argument("--wavepad", type=int, required=False, default=12,
+    parser.add_argument("--wavepad", type=int, required=False, default=10,
                         help="Number of wavelength bins to pad on boths end of extraction patch")
-    parser.add_argument("--ranks-per-bundle", type=int, default=None, 
+    parser.add_argument("--ranks-per-bundle", type=int, default=None,
                         help="number of ranks per bundle")
     args = None
     if options is None:

--- a/py/gpu_specter/spex.py
+++ b/py/gpu_specter/spex.py
@@ -55,7 +55,8 @@ def parse(options=None):
                         help="fraction of a PSF spotsize to pad in wavelengths when extracting")
     parser.add_argument("--wavepad", type=int, required=False, default=12,
                         help="Number of wavelength bins to pad on boths end of extraction patch")
-
+    parser.add_argument("--ranks-per-bundle", type=int, default=None, 
+                        help="number of ranks per bundle")
     args = None
     if options is None:
         args = parser.parse_args()
@@ -162,6 +163,7 @@ def main_gpu_specter(args=None, comm=None, timing=None, coordinator=None):
             wavepad=args.wavepad,
             wavepad_frac=args.wavepad_frac, 
             pixpad_frac=args.pixpad_frac,
+            ranks_per_bundle=args.ranks_per_bundle,
         )
         #- Pass other input data through for output
         if coordinator.is_worker_root(coordinator.rank):


### PR DESCRIPTION
This PR parametrizes the `ranks_per_bundle` variable that is used in extract_frame to decompose the mpi communicator into subgroups for extraction by bundles. For CPU extractions, this enables using multiple extraction groups instead of the current default of a single extraction group. 

