### PR TITLE
Eliminate noisy warnings

### DIFF
--- a/py/gpu_specter/core.py
+++ b/py/gpu_specter/core.py
@@ -11,7 +11,7 @@ try:
     import numba.cuda
     numba.cuda.is_available()
     import cupy as cp
-    import cupy.prof
+    from cupyx.profiler import time_range
     cp.is_available()
 except ImportError:
     pass
@@ -155,7 +155,7 @@ def assemble_bundle_patches(rankresults):
 
     return specflux, specivar, Rdiags, pixmask_fraction, chi2pix, modelimage, xyslice
 
-# @cupy.prof.TimeRangeDecorator("extract_bundle")
+# @time_range("extract_bundle")
 def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=25, nsubbundles=1, batch_subbundle=False,
     nwavestep=50, wavepad=10, comm=None, gpu=None, loglevel=None, model=None, regularize=0,
     psferr=None, pixpad_frac=0):
@@ -345,7 +345,7 @@ def extract_bundle(image, imageivar, psf, wave, fullwave, bspecmin, bundlesize=2
 
     return bundle
 
-# @cupy.prof.TimeRangeDecorator("decompose_comm")
+# @time_range("decompose_comm")
 def decompose_comm(comm=None, gpu=False, ranks_per_bundle=None):
     """Decomposes MPI communicator into frame and bundle communicators depending on
     size of communicator, number of GPU devices (if requested), and (optionally) the
@@ -414,7 +414,7 @@ def decompose_comm(comm=None, gpu=False, ranks_per_bundle=None):
 
     return bundle_comm, frame_comm
 
-# @cupy.prof.TimeRangeDecorator("extract_frame")
+# @time_range("extract_frame")
 def extract_frame(img, psf, bundlesize, specmin, nspec, wavelength=None, nwavestep=50, nsubbundles=1,
     model=None, regularize=0, psferr=None, comm=None, gpu=None, loglevel=None, timing=None, 
     wavepad=10, pixpad_frac=0.8, wavepad_frac=0.2, batch_subbundle=True, ranks_per_bundle=None):

--- a/py/gpu_specter/linalg.py
+++ b/py/gpu_specter/linalg.py
@@ -3,159 +3,18 @@
 
 import numpy
 import cupy
-import cupy.prof
 import cupyx
+
+from cupyx.profiler import time_range
 
 #- _posv and _batch_posv are superseded by cupyx.lapack.posv as of CuPy v9.0.0
 
-# @cupy.prof.TimeRangeDecorator("_batch_posv")
-# def _batch_posv(a, b):
-#     """Solve the linear equations A x = b via Cholesky factorization of A, where A
-#     is a real symmetric or complex Hermitian positive-definite matrix.
-#
-#     If matrix ``a[i]`` is not positive definite, Cholesky factorization fails and
-#     it raises an error.
-#
-#     Args:
-#         a (cupy.ndarray): Array of real symmetric or complex hermitian
-#             matrices with dimension (..., N, N).
-#         b (cupy.ndarray): right-hand side (..., N).
-#     Returns:
-#         x (cupy.ndarray): Array of solutions (..., N).
-#     """
-#     if not cupy.cusolver.check_availability('potrsBatched'):
-#         raise RuntimeError('potrsBatched is not available')
-#
-#     dtype = numpy.promote_types(a.dtype, b.dtype)
-#     dtype = numpy.promote_types(dtype, 'f')
-#
-#     if dtype == 'f':
-#         potrfBatched = cupy.cuda.cusolver.spotrfBatched
-#         potrsBatched = cupy.cuda.cusolver.spotrsBatched
-#     elif dtype == 'd':
-#         potrfBatched = cupy.cuda.cusolver.dpotrfBatched
-#         potrsBatched = cupy.cuda.cusolver.dpotrsBatched
-#     elif dtype == 'F':
-#         potrfBatched = cupy.cuda.cusolver.cpotrfBatched
-#         potrsBatched = cupy.cuda.cusolver.cpotrsBatched
-#     elif dtype == 'D':
-#         potrfBatched = cupy.cuda.cusolver.zpotrfBatched
-#         potrsBatched = cupy.cuda.cusolver.zpotrsBatched
-#     else:
-#         msg = ('dtype must be float32, float64, complex64 or complex128'
-#                ' (actual: {})'.format(a.dtype))
-#         raise ValueError(msg)
-#
-#     # Cholesky factorization
-#     a = a.astype(dtype, order='C', copy=True)
-#     ap = cupy.core._mat_ptrs(a)
-#     lda, n = a.shape[-2:]
-#     batch_size = int(numpy.prod(a.shape[:-2]))
-#
-#     handle = cupy.cuda.device.get_cusolver_handle()
-#     uplo = cupy.cuda.cublas.CUBLAS_FILL_MODE_LOWER
-#     dev_info = cupy.empty(batch_size, dtype=numpy.int32)
-#
-#     potrfBatched(handle, uplo, n, ap.data.ptr, lda, dev_info.data.ptr,
-#                  batch_size)
-#     cupy.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
-#         potrfBatched, dev_info)
-#
-#     # Cholesky solve
-#     b_shape = b.shape
-#     b = b.conj().reshape(batch_size, n, -1).astype(dtype, order='C', copy=True)
-#     bp = cupy.core._mat_ptrs(b)
-#     ldb, nrhs = b.shape[-2:]
-#     dev_info = cupy.empty(1, dtype=numpy.int32)
-#
-#     potrsBatched(handle, uplo, n, nrhs, ap.data.ptr, lda, bp.data.ptr, ldb,
-#                  dev_info.data.ptr, batch_size)
-#     cupy.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
-#         potrsBatched, dev_info)
-#
-#     return b.conj().reshape(b_shape)
-#
-# @cupy.prof.TimeRangeDecorator("_posv")
-# def _posv(a, b):
-#     """Solve the linear equations A x = b via Cholesky factorization of A,
-#     where A is a real symmetric or complex Hermitian positive-definite matrix.
-#
-#     If matrix ``A`` is not positive definite, Cholesky factorization fails
-#     and it raises an error.
-#
-#     Note: For batch input, NRHS > 1 is not currently supported.
-#
-#     Args:
-#         a (cupy.ndarray): Array of real symmetric or complex hermitian
-#             matrices with dimension (..., N, N).
-#         b (cupy.ndarray): right-hand side (..., N) or (..., N, NRHS).
-#     Returns:
-#         x (cupy.ndarray): The solution (shape matches b).
-#     """
-#
-#     cupy.linalg._util._assert_cupy_array(a, b)
-#     cupy.linalg._util._assert_nd_squareness(a)
-#
-#     if a.ndim > 2:
-#         return _batch_posv(a, b)
-#
-#     dtype = numpy.promote_types(a.dtype, b.dtype)
-#     dtype = numpy.promote_types(dtype, 'f')
-#
-#     if dtype == 'f':
-#         potrf = cupy.cuda.cusolver.spotrf
-#         potrf_bufferSize = cupy.cuda.cusolver.spotrf_bufferSize
-#         potrs = cupy.cuda.cusolver.spotrs
-#     elif dtype == 'd':
-#         potrf = cupy.cuda.cusolver.dpotrf
-#         potrf_bufferSize = cupy.cuda.cusolver.dpotrf_bufferSize
-#         potrs = cupy.cuda.cusolver.dpotrs
-#     elif dtype == 'F':
-#         potrf = cupy.cuda.cusolver.cpotrf
-#         potrf_bufferSize = cupy.cuda.cusolver.cpotrf_bufferSize
-#         potrs = cupy.cuda.cusolver.cpotrs
-#     elif dtype == 'D':
-#         potrf = cupy.cuda.cusolver.zpotrf
-#         potrf_bufferSize = cupy.cuda.cusolver.zpotrf_bufferSize
-#         potrs = cupy.cuda.cusolver.zpotrs
-#     else:
-#         msg = ('dtype must be float32, float64, complex64 or complex128'
-#                ' (actual: {})'.format(a.dtype))
-#         raise ValueError(msg)
-#
-#     a = a.astype(dtype, order='F', copy=True)
-#     lda, n = a.shape
-#
-#     handle = cupy.cuda.device.get_cusolver_handle()
-#     uplo = cupy.cuda.cublas.CUBLAS_FILL_MODE_LOWER
-#     dev_info = cupy.empty(1, dtype=numpy.int32)
-#
-#     worksize = potrf_bufferSize(handle, uplo, n, a.data.ptr, lda)
-#     workspace = cupy.empty(worksize, dtype=dtype)
-#
-#     # Cholesky factorization
-#     potrf(handle, uplo, n, a.data.ptr, lda, workspace.data.ptr,
-#           worksize, dev_info.data.ptr)
-#     cupy.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
-#         potrf, dev_info)
-#
-#     b_shape = b.shape
-#     b = b.reshape(n, -1).astype(dtype, order='F', copy=True)
-#     ldb, nrhs = b.shape
-#
-#     # Solve: A * X = B
-#     potrs(handle, uplo, n, nrhs, a.data.ptr, lda, b.data.ptr, ldb,
-#           dev_info.data.ptr)
-#     cupy.linalg._util._check_cusolver_dev_info_if_synchronization_allowed(
-#         potrs, dev_info)
-#
-#     return cupy.ascontiguousarray(b.reshape(b_shape))
 
-@cupy.prof.TimeRangeDecorator("cholesky_solve")
+@time_range("cholesky_solve")
 def cholesky_solve(a, b):
     return cupyx.lapack.posv(a, b)
 
-@cupy.prof.TimeRangeDecorator("clipped_eigh")
+@time_range("clipped_eigh")
 def clipped_eigh(a, clip_scale=1e-14):
     assert clip_scale >= 0
     w, v = cupy.linalg.eigh(a)
@@ -164,11 +23,11 @@ def clipped_eigh(a, clip_scale=1e-14):
     w = cupy.clip(w, a_min=clip_scale*cupy.max(w))
     return w, v
 
-@cupy.prof.TimeRangeDecorator("compose_eigh")
+@time_range("compose_eigh")
 def compose_eigh(w, v):
     return cupy.einsum('...ik,...k,...jk->...ij', v, w, v)
 
-@cupy.prof.TimeRangeDecorator("matrix_sqrt")
+@time_range("matrix_sqrt")
 def matrix_sqrt(a):
     #- eigen decomposition
     w, v = clipped_eigh(a)
@@ -176,7 +35,7 @@ def matrix_sqrt(a):
     q = compose_eigh(cupy.sqrt(w), v)
     return q
 
-@cupy.prof.TimeRangeDecorator("diag_block_matrix_sqrt")
+@time_range("diag_block_matrix_sqrt")
 def diag_block_matrix_sqrt(a, block_size):
     a_shape = a.shape
     n, m = a_shape[-2:]

--- a/py/gpu_specter/polynomial.py
+++ b/py/gpu_specter/polynomial.py
@@ -5,7 +5,7 @@ import numpy
 
 from numba import cuda
 import cupy
-import cupy.prof
+from cupyx.profiler import time_range
 
 @cuda.jit
 def _hermevander(x, deg, output_matrix):
@@ -19,7 +19,7 @@ def _hermevander(x, deg, output_matrix):
             for k in range(2, deg + 1):
                 output_matrix[i][j][k] = output_matrix[i][j][k-1]*x[i][j] - output_matrix[i][j][k-2]*(k-1)
 
-@cupy.prof.TimeRangeDecorator("hermevander")
+@time_range("hermevander")
 def hermevander(x, deg):
     """Temprorary wrapper that allocates memory and calls hermevander_gpu
     """
@@ -42,7 +42,7 @@ def _legvander(x, deg, output_matrix):
         for j in range(2, deg + 1):
             output_matrix[i][j] = (output_matrix[i][j-1]*x[i]*(2*j - 1) - output_matrix[i][j-2]*(j - 1)) / j
 
-@cupy.prof.TimeRangeDecorator("legvander")
+@time_range("legvander")
 def legvander(x, deg):
     """Temporary wrapper that allocates memory and defines grid before calling legvander.
     Probably won't be needed once cupy has the correpsponding legvander function.

--- a/py/gpu_specter/polynomial.py
+++ b/py/gpu_specter/polynomial.py
@@ -7,6 +7,11 @@ from numba import cuda
 import cupy
 from cupyx.profiler import time_range
 
+from numba.core.errors import NumbaPerformanceWarning
+import warnings
+
+warnings.simplefilter('ignore', category=NumbaPerformanceWarning)
+
 @cuda.jit
 def _hermevander(x, deg, output_matrix):
     i = cuda.blockIdx.x


### PR DESCRIPTION
This PR addresses #69 and #70.

Note that the performance warnings from numba.cuda are potentially helpful but not especially concerning. We know we are under utilizing the GPU in some areas which is why we are using CUDA MPS to have multiple MPI ranks share GPUs. Numba is not aware of that.