### PR TITLE
Return value from desi_mps_wrapper

### DIFF
--- a/bin/desi_mps_wrapper
+++ b/bin/desi_mps_wrapper
@@ -64,6 +64,9 @@ fi
 # Run the command
 "$@"
 
+# Store return value
+retval=$?
+
 # Stop MPS on each node from local rank 0
 if [ $SLURM_LOCALID -eq 0 ]; then
     # Stop if running
@@ -80,3 +83,6 @@ if [ $SLURM_LOCALID -eq 0 ]; then
         killall nvidia-cuda-mps-server
     fi
 fi
+
+# Return value from the command
+exit $retval


### PR DESCRIPTION
Modifies `desi_mps_wrapper` to return the same exit code as the command it is wrapping, so that the behavior of batch scripts in the pipeline that call desispec spcripts, such as `desi_proc` and `desi_proc_tilenight`, remains unchanged.