### PR TITLE
return xflux in ex2d_patch and use xflux for chi2pix

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,9 +17,10 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                python-version: [3.8]  # fitsio does not like Python < 3.7, astropy does not like Python < 3.8, might be too soon for 3.9.
-                astropy-version: ['==4.0.1.post1', '==5.0']  # everest & fuji versions
-                fitsio-version: ['==1.1.2', '==1.1.6']  # everest & fuji versions
+                python-version: ['3.9'] # fuji+guadalupe version
+                astropy-version: ['==5.0']  # fuji+guadalupe version
+                fitsio-version: ['==1.1.6']  # fuji+guadalupe version
+                numpy-version: ['<1.23']  # to keep asscalar, used by astropy
 
         steps:
             - name: Checkout code
@@ -35,6 +36,7 @@ jobs:
                 python -m pip install --upgrade pip wheel
                 python -m pip install pytest
                 python -m pip install -r requirements.txt
+                python -m pip install -U 'numpy${{ matrix.numpy-version }}'
                 python -m pip install -U 'astropy${{ matrix.astropy-version }}'
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'


### PR DESCRIPTION
Here is a PR to use the unconvolved extracted flux (`xflux`) instead of the reconvolved flux (`flux = R * xflux`) in the calculation of `chi2pix` (see #75 for details).

Summary of changes:
* add raw extracted flux `xflux` to the tuple returned by `ex2d_patch`
* use `xflux` in calculation of `chi2pix` instead of `flux` 
* update references to `ex2d_patch` throughout gpu_specter to handle change to return values

cc: @sbailey @marcelo-alvarez 