### PR TITLE
fix the numpy 2.0 error

### DIFF
--- a/py/gpu_specter/io.py
+++ b/py/gpu_specter/io.py
@@ -17,7 +17,8 @@ def native_endian(data):
     if data.dtype.isnative:
         return data
     else:
-        return data.byteswap().newbyteorder()
+        data = data.byteswap()
+        return data.view(data.dtype.newbyteorder())
 
 def read_psf(filename):
     """


### PR DESCRIPTION
Hi, 

while trying to run specter test with numpy 2.0 I get this error

```
        else:
>           return data.byteswap().newbyteorder()
E           AttributeError: `newbyteorder` was removed from the ndarray class in NumPy 2.0. Use `arr.view(arr.dtype.newbyteorder(order))` instead.
```
The patch fixes that (based on https://numpy.org/devdocs/user/byteswapping.html )

(the test failure below seems unrelated to the patch) 
