### PR TITLE
Add numpy2 test

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
                     python-version: '3.10'
                     astropy-version: '<7'
                     fitsio-version: '==1.2.4'
-                    numpy-version: '==2.1.3'
+                    numpy-version: '==2.0.2'
 
         steps:
             - name: Checkout code

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,11 +22,11 @@ jobs:
                 fitsio-version: ['==1.1.6']  # fuji+guadalupe version
                 numpy-version: ['<1.23']  # to keep asscalar, used by astropy
                 include:
-                  os: [ubuntu-latest]
-                  python-version: ['3.10']
-                  astropy-version: ['==6.1.7']
-                  fitsio-version: ['==1.2.4']
-                  numpy-version: ['2.1.3']
+                  - os: [ubuntu-latest]
+                    python-version: ['3.10']
+                    astropy-version: ['==6.1.7']
+                    fitsio-version: ['==1.2.4']
+                    numpy-version: ['2.1.3']
 
         steps:
             - name: Checkout code

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,10 +21,16 @@ jobs:
                 astropy-version: ['==5.0']  # fuji+guadalupe version
                 fitsio-version: ['==1.1.6']  # fuji+guadalupe version
                 numpy-version: ['<1.23']  # to keep asscalar, used by astropy
+                include:
+                  os: [ubuntu-latest]
+                  python-version: ['3.10']
+                  astropy-version: ['==6.1.7']
+                  fitsio-version: ['==1.2.4']
+                  numpy-version: ['2.1.3']
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
               with:
                 fetch-depth: 0
             - name: System packages
@@ -32,7 +38,7 @@ jobs:
                  sudo apt install libbz2-dev
               # needed for fitsio... 
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v5
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,11 +22,11 @@ jobs:
                 fitsio-version: ['==1.1.6']  # fuji+guadalupe version
                 numpy-version: ['<1.23']  # to keep asscalar, used by astropy
                 include:
-                  - os: [ubuntu-latest]
+                  - os: ubuntu-latest
                     python-version: '3.10'
                     astropy-version: '<7'
                     fitsio-version: '==1.2.4'
-                    numpy-version: '2.1.3'
+                    numpy-version: '==2.1.3'
 
         steps:
             - name: Checkout code

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,10 +23,10 @@ jobs:
                 numpy-version: ['<1.23']  # to keep asscalar, used by astropy
                 include:
                   - os: [ubuntu-latest]
-                    python-version: ['3.10']
-                    astropy-version: ['==6.1.7']
-                    fitsio-version: ['==1.2.4']
-                    numpy-version: ['2.1.3']
+                    python-version: '3.10'
+                    astropy-version: '<7'
+                    fitsio-version: '==1.2.4'
+                    numpy-version: '2.1.3'
 
         steps:
             - name: Checkout code


### PR DESCRIPTION
Here, I' add one more test with numpy 2.0  to the github configuration matrix. 
I also bump the github action version. 

the numpy 2.0.2 is the highest version that works (because of numba). 
The astropy version is somewhat arbitrary (maybe 7.0 would work as well) 